### PR TITLE
find module in mod.modules instead of applcation.modules when LoadSubDyn

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -695,7 +695,7 @@ namespace Kaenx.Creator.Classes
                     case Models.Dynamic.DynModule dm:
                         if(dm._module != -1)
                         {
-                            dm.ModuleObject = general.Application.Modules.Single(m => m.UId == dm._module);
+                            dm.ModuleObject = mod.Modules.Single(m => m.UId == dm._module);
                             foreach(Models.Dynamic.DynModuleArg arg in dm.Arguments)
                             {
                                 if(arg._argId != -1)


### PR DESCRIPTION
for submodule in a existing module, find the module in modules of current node, instead of the global application.modules