### PR TITLE
[bugfix] LdCtrlCompareProp for HW Type has to be individual

### DIFF
--- a/Classes/ExportHelper.cs
+++ b/Classes/ExportHelper.cs
@@ -467,10 +467,8 @@ namespace Kaenx.Creator.Classes
                         {
                             if(xele.Attribute("ObjIdx").Value == "0" && xele.Attribute("PropId").Value == "12")
                                 xele.Attribute("InlineData").Value = GetManuId();
-                            /*
-                            if(xele.Attribute("ObjIdx").Value == "0" && xele.Attribute("PropId").Value == "78")
+                            if(general.IsOpenKnx && xele.Attribute("ObjIdx").Value == "0" && xele.Attribute("PropId").Value == "78")
                                 xele.Attribute("InlineData").Value = $"0000{general.ManufacturerId:X2}{general.Info.AppNumber:X2}{general.Application.Number:X2}00";
-                            */
                             break;
                         }
                     }

--- a/Classes/ExportHelper.cs
+++ b/Classes/ExportHelper.cs
@@ -467,9 +467,10 @@ namespace Kaenx.Creator.Classes
                         {
                             if(xele.Attribute("ObjIdx").Value == "0" && xele.Attribute("PropId").Value == "12")
                                 xele.Attribute("InlineData").Value = GetManuId();
-                                
+                            /*
                             if(xele.Attribute("ObjIdx").Value == "0" && xele.Attribute("PropId").Value == "78")
                                 xele.Attribute("InlineData").Value = $"0000{general.ManufacturerId:X2}{general.Info.AppNumber:X2}{general.Application.Number:X2}00";
+                            */
                             break;
                         }
                     }


### PR DESCRIPTION
The LdCtrlCompareProp for Hardware Type (PropId 78) is not derivable from manucaturer and application id. 
For example in knxprod for binary input 4-fold from MDT, there is a Hardware Type identification of `00000000011F00000000`. 
But with previous calculation it is `000083322000`.

[MDT_KP_Binaereingang_V20a.zip](https://github.com/user-attachments/files/16945118/MDT_KP_Binaereingang_V20a.zip)
