### PR TITLE
[bugfix] prevent from memory calculation exception

### DIFF
--- a/Models/Memory.cs
+++ b/Models/Memory.cs
@@ -143,9 +143,9 @@ namespace Kaenx.Creator.Models
                     MemorySection sec = Sections.Single(s => s.Address == secAddr);
                     int byteIndex = paraAddr - secAddr;
                     sec.Bytes[byteIndex].SetByteUsed(usage, usedBy);
-                }catch(Exception e){
-                    if (e is InvalidOperationException){
-                        return;
+                }catch(Exception ex){
+                    if (ex is InvalidOperationException){
+                        throw new Exception("out_of_memory");
                     }
                 }
             }

--- a/Models/Memory.cs
+++ b/Models/Memory.cs
@@ -143,10 +143,8 @@ namespace Kaenx.Creator.Models
                     MemorySection sec = Sections.Single(s => s.Address == secAddr);
                     int byteIndex = paraAddr - secAddr;
                     sec.Bytes[byteIndex].SetByteUsed(usage, usedBy);
-                }catch(Exception ex){
-                    if (ex is InvalidOperationException){
-                        throw new Exception("out_of_memory");
-                    }
+                }catch(InvalidOperationException ex){
+                    throw new OutOfMemoryException("bytes_used_outside_of_memory", ex);
                 }
             }
         }

--- a/Models/Memory.cs
+++ b/Models/Memory.cs
@@ -139,9 +139,15 @@ namespace Kaenx.Creator.Models
             {
                 int paraAddr = Address + offset + i;
                 int secAddr = paraAddr - (paraAddr % 16);
-                MemorySection sec = Sections.Single(s => s.Address == secAddr);
-                int byteIndex = paraAddr - secAddr;
-                sec.Bytes[byteIndex].SetByteUsed(usage, usedBy);
+                try{
+                    MemorySection sec = Sections.Single(s => s.Address == secAddr);
+                    int byteIndex = paraAddr - secAddr;
+                    sec.Bytes[byteIndex].SetByteUsed(usage, usedBy);
+                }catch(Exception e){
+                    if (e is InvalidOperationException){
+                        return;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
If there is a memory overrun this helps to prevent against a unknown exception.

A memory overrun can be provoked if you take an BCU1 project and set the comObject Table too high, so it goes over the end of the memory section.

Maybe there should be a Waring in KAENX Creator GUI, but I dont know how to implement this from share.